### PR TITLE
Update RPC page to v0.44.5

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -433,7 +433,7 @@ const routes = [
   },
   {
     path: "/rpc",
-    redirect: "/rpc/v0.42.6"
+    redirect: "/rpc/v0.44.5"
   },
   {
     path: "/rpc/:version?",

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1,5 +1,20 @@
 [
   {
+    "url": "https://raw.githubusercontent.com/cosmos/cosmos-sdk/v0.44.5/client/docs/swagger-ui/swagger.yaml",
+    "label": "Cosmos SDK v0.44.5 (Gaia v6.0.0 / cosmoshub-4)",
+    "key": "v0.44.5"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/cosmos/ibc-go/release/v2.0.x/docs/client/swagger-ui/swagger.yaml",
+    "label": "IBC (Gaia v6.0.0 / cosmoshub-4)",
+    "key": "ibc"
+  },
+  {
+    "url": "https://raw.githubusercontent.com/tendermint/liquidity/develop/client/docs/swagger-ui/swagger.yaml",
+    "label": "Gravity DEX (Gaia v6.0.0 / cosmoshub-4)",
+    "key": "gravity-dex"
+  },
+  {
     "url": "https://raw.githubusercontent.com/cosmos/cosmos-sdk/v0.42.6/client/docs/swagger-ui/swagger.yaml",
     "label": "Cosmos SDK v0.42.6 (Gaia v5.0.2 / cosmoshub-4)",
     "key": "v0.42.6"
@@ -8,11 +23,6 @@
     "url": "https://raw.githubusercontent.com/cosmos/ibc-go/55afb90cabab436204a89e3bea37fc1e693f1ea6/docs/client/swagger-ui/swagger.yaml",
     "label": "IBC (Gaia v5.0.2 / cosmoshub-4)",
     "key": "ibc"
-  },
-  {
-    "url": "https://raw.githubusercontent.com/tendermint/liquidity/develop/client/docs/swagger-ui/swagger.yaml",
-    "label": "Gravity DEX (Gaia v5.0.2 / cosmoshub-4)",
-    "key": "gravity-dex"
   },
   {
     "url": "https://raw.githubusercontent.com/cosmos/cosmos-sdk/v0.41.4/client/docs/swagger-ui/swagger.yaml",


### PR DESCRIPTION
The current RPC interface on v1.cosmos.network is outdated. These changes update to SDK v0.44.5, Gaia v6 (Vega) and IBC 2.0.x